### PR TITLE
fix: download url has been changed by noaa

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -102,7 +102,7 @@ export default class Client {
       field.resolution,
       forecastOffset
     )
-    let url = `gfs.${y}${m}${d}${h}/${gfsFileName}`
+    let url = `gfs.${y}${m}${d}/${h}/${gfsFileName}`
 
     return this.getGribIndex(url).then((index) => {
       let entry = index.find(


### PR DESCRIPTION
The data structure of NOAA data has been changed since 13-Jun-2019 20:41: https://www.ftp.ncep.noaa.gov/data/nccf/com/gfs/prod/